### PR TITLE
Updated "leads" shortlinks to point to HubSpot

### DIFF
--- a/shortlinks.csv
+++ b/shortlinks.csv
@@ -19,8 +19,10 @@ linkedin,https://www.linkedin.com/company/hyphacoop/
 cron,https://github.com/hyphacoop/worker-coop-scripts
 scheduled-tasks,https://github.com/hyphacoop/worker-coop-scripts
 inventory,https://hackmd.io/@patcon/HyH0W9bAE
-leads,https://docs.google.com/spreadsheets/d/1LyElXvLj7ASclSPQqcgOnuEWqBWBStilEfOhIosZzhA/edit#gid=0
+leads,https://app.hubspot.com/contacts/6514161/deals/board/view/all/?
 opportunities,https://link.hypha.coop/leads
+prospects,https://link.hypha.coop/leads
+deals,https://link.hypha.coop/leads
 conversions,https://docs.google.com/spreadsheets/d/1LyElXvLj7ASclSPQqcgOnuEWqBWBStilEfOhIosZzhA/edit#gid=30829554
 slogans,https://hackmd.io/s/HkRaA_woE
 chants,https://hackmd.io/s/Bk-BO6viN


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/organizing/issues/119

Added some pseudonym shortlinks too. If these distinct terms become more meaningful, we could later have them direct link to filters of the HubSpot deals dashboard.

Leaving this for now, until we've fully migrated from our spreadsheet.